### PR TITLE
clostrum-basic subprotocol for alternate cell representations

### DIFF
--- a/Basic/basic.lisp
+++ b/Basic/basic.lisp
@@ -149,7 +149,7 @@
         nil)))
 
 (defmethod sys:ensure-type-cell (client (environment basic-environment) symbol)
-  (cell (ensure-type-entry symbol environment)))
+  (cell (ensure-type-entry client symbol environment)))
 
 (defmethod sys:type-expander (client (environment basic-environment) symbol)
   (let ((entry (type-entry symbol environment)))
@@ -160,7 +160,7 @@
     (new client (environment basic-environment) symbol)
   (let ((entry (if (null new)
                    (type-entry symbol environment)
-                   (ensure-type-entry symbol environment))))
+                   (ensure-type-entry client symbol environment))))
     (unless (null entry)
       (setf (type-expander entry) new)))
   new)

--- a/Basic/packages.lisp
+++ b/Basic/packages.lisp
@@ -7,4 +7,5 @@
   (:shadow #:compiler-macro-function #:inline #:ftype #:optimize)
   (:export #:run-time-environment
            #:compilation-environment
-           #:top-type))
+           #:top-type)
+  (:export #:make-operator-cell #:make-variable-cell #:make-type-cell))


### PR DESCRIPTION
MAKE-OPERATOR-CELL et al. can be specialized by clients. This allows the usage of most of clostrum-basic (macros, types, etc.) as-is while controlling how cells work.